### PR TITLE
use maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     ]
 
     repositories {
-      maven {url 'https://maven-central.storage.googleapis.com'}
+        mavenCentral()
     }
 
     dependencies {
@@ -21,7 +21,7 @@ buildscript {
 }
 
 repositories {
-  maven {url 'https://maven-central.storage.googleapis.com'}
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
The actual maven mirror no longer contains the project dependencies.

If you try building the project you will get the following error:
```sh
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'campr-injection-workshop'.
> Could not resolve all dependencies for configuration ':classpath'.
   > Could not find org.springframework.boot:spring-boot-gradle-plugin:1.2.1.RELEASE.
     Searched in the following locations:
         https://maven-central.storage.googleapis.com/org/springframework/boot/spring-boot-gradle-plugin/1.2.1.RELEASE/spring-boot-gradle-plugin-1.2.1.RELEASE.pom
         https://maven-central.storage.googleapis.com/org/springframework/boot/spring-boot-gradle-plugin/1.2.1.RELEASE/spring-boot-gradle-plugin-1.2.1.RELEASE.jar
     Required by:
         :campr-injection-workshop:unspecified

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 18.893 secs
```

Switching back to maven central solves this problem.